### PR TITLE
Modify `.gitignore` to ignore `.vscode` config dir:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# VSCode settings files:
+.vscode
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
The VSCode project settings files live under the `.vscode/` dir, add this dir
to `.gitignore` so that it is skipped by git.
