### PR TITLE
Add `mypy` to `requirements.in`:

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,4 +3,5 @@ pip-tools
 pytest
 pep8
 flake8
+mypy
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,10 @@ iniconfig==1.1.1
     # via pytest
 mccabe==0.6.1
     # via flake8
+mypy==0.931
+    # via -r requirements.in
+mypy-extensions==0.4.3
+    # via mypy
 numpy==1.22.2
     # via -r requirements.in
 packaging==21.3
@@ -58,10 +62,13 @@ toml==0.10.2
     # via tox
 tomli==2.0.1
     # via
+    #   mypy
     #   pep517
     #   pytest
 tox==3.24.5
     # via -r requirements.in
+typing-extensions==4.0.1
+    # via mypy
 virtualenv==20.13.1
     # via tox
 wheel==0.37.1


### PR DESCRIPTION
Add `mypy` as requirement in `requirement.in` and recompile the
`requirements.txt` using `tox -e update-pins`.

`mypy` is required for the tox `mypy` scan to complete, and was missed
out on earlier.
