### PR TITLE
Tox workflow to run on pull_requests:

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,5 +1,9 @@
 name: Tox
-on: push
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
   # First, use tox-gh-matrix to construct a build matrix
   # from your tox.ini:


### PR DESCRIPTION
Modify the `tox.yml` github workflow file so that the tox configured
tests run on an forked branches from pull requests against this repo,
and not just on branches in this repo.
