### PR TITLE
Add `mypy.ini` configuration file:

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True


### PR DESCRIPTION
Add the `mypy.ini` configuration file to the root of the directory, with
the configuration
```ini
ignore_missing_imports = True
```
set, this will suppress mypy flagging any imports of our module code as
missing stubs (which it is), and just being a nuisance in general.

An example of mypy acting up can be seen at https://github.com/Tiernan8r/quantum_computing_project/runs/5260035814?check_suite_focus=true#step:5:10
