### PR TITLE
Implement gates

### DIFF
--- a/qcp/constants.py
+++ b/qcp/constants.py
@@ -1,0 +1,8 @@
+import matrix
+
+IDENTITY = matrix([[1, 0], [0, 1]])
+TWO_HADAMARD = matrix([[1, 1], [1, -1]])
+ZERO_VECTOR = matrix([[1], [0]])
+ONE_VECTOR = matrix([[0], [1]])
+PAULI_X = matrix([[0, 1], [1, 0]])
+PAULI_Z = matrix([[1, 0], [0, -1]])

--- a/qcp/constants.py
+++ b/qcp/constants.py
@@ -1,7 +1,8 @@
 from matrix import Matrix
+import math
 
 IDENTITY = Matrix([[1, 0], [0, 1]])
-TWO_HADAMARD = Matrix([[1, 1], [1, -1]])
+TWO_HADAMARD = Matrix([[1, 1], [1, -1]]) * (1/math.sqrt(2))
 ZERO_VECTOR = Matrix([[1], [0]])
 ONE_VECTOR = Matrix([[0], [1]])
 PAULI_X = Matrix([[0, 1], [1, 0]])

--- a/qcp/constants.py
+++ b/qcp/constants.py
@@ -1,8 +1,8 @@
-from matrix import matrix
+from matrix import Matrix
 
-IDENTITY = matrix([[1, 0], [0, 1]])
-TWO_HADAMARD = matrix([[1, 1], [1, -1]])
-ZERO_VECTOR = matrix([[1], [0]])
-ONE_VECTOR = matrix([[0], [1]])
-PAULI_X = matrix([[0, 1], [1, 0]])
-PAULI_Z = matrix([[1, 0], [0, -1]])
+IDENTITY = Matrix([[1, 0], [0, 1]])
+TWO_HADAMARD = Matrix([[1, 1], [1, -1]])
+ZERO_VECTOR = Matrix([[1], [0]])
+ONE_VECTOR = Matrix([[0], [1]])
+PAULI_X = Matrix([[0, 1], [1, 0]])
+PAULI_Z = Matrix([[1, 0], [0, -1]])

--- a/qcp/constants.py
+++ b/qcp/constants.py
@@ -1,4 +1,4 @@
-import matrix
+from matrix import matrix
 
 IDENTITY = matrix([[1, 0], [0, 1]])
 TWO_HADAMARD = matrix([[1, 1], [1, -1]])

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -1,4 +1,4 @@
-from matrix import matrix
+from matrix import Matrix
 import constants as c
 from tensor_product import tensor_product
 
@@ -10,8 +10,8 @@ Params:
 '''
 
 
-def multi_hadamard(size, targets):
-    h = matrix([[1]])
+def multi_hadamard(size: int, targets: list[int]):
+    h = Matrix([[1]])
 
     for i in range(size):
         if i in targets:
@@ -22,8 +22,8 @@ def multi_hadamard(size, targets):
     return h
 
 
-def multi_x(size, targets):
-    x = matrix([1])
+def multi_x(size: int, targets: list[int]):
+    x = Matrix([1])
 
     for i in range(size):
         if i in targets:
@@ -33,8 +33,8 @@ def multi_x(size, targets):
     return x
 
 
-def multi_z(size, targets):
-    z = matrix([1])
+def multi_z(size: int, targets: list[int]):
+    z = Matrix([1])
 
     for i in range(size):
         if i in targets:
@@ -45,7 +45,26 @@ def multi_z(size, targets):
 
 
 def control_x(size, control, target):
-    pass
+    m = []
+
+    for i in range(0, 2 ** size):
+        f = '0' + str(size) + 'b'
+        binary = list(format(i, f))
+
+        if binary[-control] == "1":
+            if binary[-target] == "0":
+                binary[-target] = "1"
+            else:
+                binary[-target] = "0"
+
+        num = "".join(binary)
+        number = int(num, 2)
+
+        row = zeros_list(number)
+        row[number] = 1
+        m.append(row)
+    x = Matrix(m)
+    return x
 
 
 def control_z(size, control, target):
@@ -54,3 +73,10 @@ def control_z(size, control, target):
 
 def toffoli(size, control1, control2, target):
     pass
+
+
+def zeros_list(n):
+    x = []
+    for i in range(n):
+        x.append(0)
+    return x

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -13,11 +13,12 @@ Params:
 def multi_hadamard(size: int, targets: list[int]):
     h = Matrix([[1]])
 
+    t = [x - 1 for x in targets]
     for i in range(size):
-        if i in targets:
-            h = tensor_product(h, c.TWO_HADAMARD)
+        if i in t:
+            h = tensor_product(c.TWO_HADAMARD, h)
         else:
-            h = tensor_product(h, c.IDENTITY)
+            h = tensor_product(c.IDENTITY, h)
 
     return h
 
@@ -25,23 +26,30 @@ def multi_hadamard(size: int, targets: list[int]):
 def multi_x(size: int, targets: list[int]):
     x = Matrix([1])
 
+    t = [x - 1 for x in targets]
     for i in range(size):
-        if i in targets:
-            x = tensor_product(x, c.PAULI_X)
+        if i in t:
+            x = tensor_product(c.PAULI_X, x)
         else:
-            x = tensor_product(x, c.IDENTITY)
+            x = tensor_product(c.IDENTITY, x)
     return x
 
 
 def multi_z(size: int, targets: list[int]):
     z = Matrix([1])
+    t = [x - 1 for x in targets]
 
     for i in range(size):
-        if i in targets:
-            z = tensor_product(z, c.PAULI_Z)
+        if i in t:
+            z = tensor_product(c.PAULI_Z, z)
         else:
-            z = tensor_product(z, c.IDENTITY)
+            z = tensor_product(c.IDENTITY, z)
     return z
+
+
+def multi_phase_shift(size, phi):
+
+    return
 
 
 def control_x(size, control, target):
@@ -60,7 +68,7 @@ def control_x(size, control, target):
         num = "".join(binary)
         number = int(num, 2)
 
-        row = zeros_list(number)
+        row = zeros_list(2 ** size)
         row[number] = 1
         m.append(row)
     x = Matrix(m)
@@ -68,11 +76,26 @@ def control_x(size, control, target):
 
 
 def control_z(size, control, target):
-    pass
+    m = []
+
+    for i in range(0, 2 ** size):
+        f = '0' + str(size) + 'b'
+        binary = list(format(i, f))
+
+        row = zeros_list(2 ** size)
+
+        if binary[-control] == "1" and binary[-target] == "1":
+            row[i] = -1
+        else:
+            row[i] = 1
+        m.append(row)
+    z = Matrix(m)
+    return z
 
 
 def toffoli(size, control1, control2, target):
     pass
+
 
 
 def zeros_list(n):
@@ -80,3 +103,8 @@ def zeros_list(n):
     for i in range(n):
         x.append(0)
     return x
+
+
+def phase_shift(size, phi):
+
+    return

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -4,16 +4,22 @@ from matrix import Matrix
 import constants as c
 from tensor_product import tensor_product
 
-'''
-Multi_Gates: constructs a large circuit matrix which acts as a gate that applies a specific gate to one or more qubits 
-Params:
-    size - total number of qubits we're working with
-    targets - the specific qubits the gate is applied to (starting from the 1st qubit)
-'''
 
+# Notation note : |001> represents a 3 qubit system where the first qubit is |1> and the second and third qubit is |0>
+# Targets and Controls work off this notation
 
-def multi_gate(size, targets, gate, phi=complex(0)):
-    g = None
+def multi_gate(size: int, targets: list[int], gate: str, phi=complex(0)):
+    """
+    Constructs a (2**size by 2**size) gate matrix that applies a specific gate to one or more specified qubits
+
+    :param size: total number of qubits in circuit -> int
+    :param targets: list of qubits the specified gate will be applied to -> List[int]
+    :param gate: string character representing which specified gate we want to apply;
+                                h = hadamard, x = Pauli x, z = Pauli z, p = Phase gate
+    :param phi: Phase angle for the phase gate -> complex number
+    :return: Matrix([int])
+    """
+
     if gate == "h":
         g = c.TWO_HADAMARD
     elif gate == "x":
@@ -37,6 +43,13 @@ def multi_gate(size, targets, gate, phi=complex(0)):
 
 
 def control_x(size, controls, target):
+    """
+    Constructs a (2**size by 2**size) control-x gate with given controls and target
+    :param size: total number of qubits in circuit ->
+    :param controls: List of control qubits -> List[int]
+    :param target: target qubit the x gate will be applied to -> int
+    :return: Matrix(int)
+    """
     m = []
 
     for i in range(0, 2 ** size):
@@ -62,6 +75,13 @@ def control_x(size, controls, target):
 
 
 def control_z(size, controls, target):
+    """
+    Constructs a (2**size by 2**size) control-z gate with given controls and target
+    :param size: total number of qubits in circuit ->
+    :param controls: List of control qubits -> List[int]
+    :param target: target qubit the z gate will be applied to -> int
+    :return: Matrix(int)
+    """
     m = []
 
     for i in range(0, 2 ** size):
@@ -81,6 +101,15 @@ def control_z(size, controls, target):
 
 
 def control_phase(size, controls, target, phi):
+    """
+    Constructs a (2**size by 2**size) control-phase gate with given controls and target
+    :param size: total number of qubits in circuit ->
+    :param controls: List of control qubits -> List[int]
+    :param target: target qubit the phase gate will be applied to -> int
+    :param phi: angle the target qubit will be phase shifted by -> complex
+    :return: Matrix(complex)
+    """
+
     m = []
 
     for i in range(0, 2 ** size):
@@ -100,6 +129,11 @@ def control_phase(size, controls, target, phi):
 
 
 def zeros_list(n):
+    """
+    Creates a list of size n full of zeros
+    :param n: size of list
+    :return: list[int]
+    """
     x = []
     for i in range(n):
         x.append(0 + 0j)
@@ -107,4 +141,9 @@ def zeros_list(n):
 
 
 def phase_shift(phi):
+    """
+    Creates a 2 x 2 phase shift matrix
+    :param phi: angle the qubit is phase shifted by
+    :return: Matrix(complex)
+    """
     return Matrix([[1, 0], [0, cmath.exp(1j * phi)]])

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -2,23 +2,55 @@ from matrix import matrix
 import constants as c
 from tensor_product import tensor_product
 
+'''
+Multi_Gates: constructs a large circuit matrix which acts as a gate that applies a specific gate to one or more qubits 
+Params:
+    size - total number of qubits we're working with
+    targets - the specific qubits the gate is applied to (starting from the 0th qubit)
+'''
 
-def hadamard(size, targets):
-    m = c.IDENTITY
+
+def multi_hadamard(size, targets):
+    h = matrix([[1]])
 
     for i in range(size):
         if i in targets:
-            m = tensor_product(m, c.TWO_HADAMARD)
+            h = tensor_product(h, c.TWO_HADAMARD)
         else:
-            m = tensor_product(m, c.IDENTITY)
+            h = tensor_product(h, c.IDENTITY)
 
-    h = matrix(m.get_state())
     return h
 
 
-def control_x():
+def multi_x(size, targets):
+    x = matrix([1])
+
+    for i in range(size):
+        if i in targets:
+            x = tensor_product(x, c.PAULI_X)
+        else:
+            x = tensor_product(x, c.IDENTITY)
+    return x
+
+
+def multi_z(size, targets):
+    z = matrix([1])
+
+    for i in range(size):
+        if i in targets:
+            z = tensor_product(z, c.PAULI_Z)
+        else:
+            z = tensor_product(z, c.IDENTITY)
+    return z
+
+
+def control_x(size, control, target):
     pass
 
 
-def control_z():
+def control_z(size, control, target):
+    pass
+
+
+def toffoli(size, control1, control2, target):
     pass

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -10,7 +10,8 @@ from typing import List
 # |1> and the second and third qubit is |0>
 # Targets and Controls work off this notation but you only need to enter the
 # number of the qubit you want to target/control
-def multi_gate(size: int, targets: list[int], gate: str, phi=complex(0)) -> Matrix:
+def multi_gate(size: int, targets: List[int], gate: str, phi=complex(0)) \
+        -> Matrix:
     """
     Constructs a (2**size by 2**size) gate matrix that applies a
     specific gate to one or more specified qubits
@@ -48,7 +49,7 @@ def multi_gate(size: int, targets: list[int], gate: str, phi=complex(0)) -> Matr
     return m
 
 
-def control_x(size, controls, target):
+def control_x(size: int, controls: List[int], target: int):
     """
     Constructs a (2**size by 2**size) control-x gate with
     given controls and target
@@ -81,7 +82,7 @@ def control_x(size, controls, target):
     return x
 
 
-def control_z(size, controls, target):
+def control_z(size: int, controls: List[int], target: int):
     """
     Constructs a (2**size by 2**size) control-z gate with
      given controls and target
@@ -109,7 +110,8 @@ def control_z(size, controls, target):
     return z
 
 
-def control_phase(size, controls, target, phi):
+def control_phase(size: int, controls: List[int], target: int,
+                  phi: complex):
     """
     Constructs a (2**size by 2**size) control-phase gate with
      given controls and target
@@ -140,7 +142,7 @@ def control_phase(size, controls, target, phi):
     return p
 
 
-def zeros_list(n):
+def zeros_list(n: int):
     """
     Creates a list of size n full of zeros
     :param n: size of list
@@ -149,7 +151,7 @@ def zeros_list(n):
     return [(0 + 0j) for _ in range(n)]
 
 
-def phase_shift(phi):
+def phase_shift(phi: complex):
     """
     Creates a 2 x 2 phase shift matrix
     :param phi: angle the qubit is phase shifted by

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -4,7 +4,6 @@ from matrix import Matrix
 import constants as c
 from tensor_product import tensor_product
 
-
 '''
 Multi_Gates: constructs a large circuit matrix which acts as a gate that applies a specific gate to one or more qubits 
 Params:
@@ -13,53 +12,26 @@ Params:
 '''
 
 
-def multi_hadamard(size: int, targets: list[int]):
-    h = Matrix([[1]])
+def multi_gate(size, targets, gate, phi=complex(0)):
+    g = None
+    if gate == "h":
+        g = c.TWO_HADAMARD
+    elif gate == "x":
+        g = c.PAULI_X
+    elif gate == "z":
+        g = c.PAULI_Z
+    elif gate == "p":
+        g = phase_shift(phi)
 
-    t = [x - 1 for x in targets]
-    for i in range(size):
-        if i in t:
-            h = tensor_product(c.TWO_HADAMARD, h)
-        else:
-            h = tensor_product(c.IDENTITY, h)
-
-    return h
-
-
-def multi_x(size: int, targets: list[int]):
-    x = Matrix([1])
-
-    t = [x - 1 for x in targets]
-    for i in range(size):
-        if i in t:
-            x = tensor_product(c.PAULI_X, x)
-        else:
-            x = tensor_product(c.IDENTITY, x)
-    return x
-
-
-def multi_z(size: int, targets: list[int]):
-    z = Matrix([1])
+    m = Matrix([1])
     t = [x - 1 for x in targets]
 
     for i in range(size):
         if i in t:
-            z = tensor_product(c.PAULI_Z, z)
+            m = tensor_product(g, m)
         else:
-            z = tensor_product(c.IDENTITY, z)
-    return z
-
-
-def multi_phase_shift(size, targets, phi):
-    p = Matrix([1])
-    t = [x - 1 for x in targets]
-
-    for i in range(size):
-        if i in t:
-            p = tensor_product(phase_shift(phi), p)
-        else:
-            p = tensor_product(c.IDENTITY, p)
-    return p
+            m = tensor_product(c.IDENTITY, m)
+    return m
 
 
 def control_x(size, control, target):

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -1,0 +1,24 @@
+from matrix import matrix
+import constants as c
+from tensor_product import tensor_product
+
+
+def hadamard(size, targets):
+    m = c.IDENTITY
+
+    for i in range(size):
+        if i in targets:
+            m = tensor_product(m, c.TWO_HADAMARD)
+        else:
+            m = tensor_product(m, c.IDENTITY)
+
+    h = matrix(m.get_state())
+    return h
+
+
+def control_x():
+    pass
+
+
+def control_z():
+    pass

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -22,6 +22,8 @@ def multi_gate(size, targets, gate, phi=complex(0)):
         g = c.PAULI_Z
     elif gate == "p":
         g = phase_shift(phi)
+    else:
+        return
 
     m = Matrix([1])
     t = [x - 1 for x in targets]
@@ -34,14 +36,16 @@ def multi_gate(size, targets, gate, phi=complex(0)):
     return m
 
 
-def control_x(size, control, target):
+def control_x(size, controls, target):
     m = []
 
     for i in range(0, 2 ** size):
         f = '0' + str(size) + 'b'
         binary = list(format(i, f))
 
-        if binary[-control] == "1":
+        conditions = [binary[-i] == "1" for i in controls]
+
+        if all(conditions):
             if binary[-target] == "0":
                 binary[-target] = "1"
             else:
@@ -57,7 +61,7 @@ def control_x(size, control, target):
     return x
 
 
-def control_z(size, control, target):
+def control_z(size, controls, target):
     m = []
 
     for i in range(0, 2 ** size):
@@ -65,8 +69,9 @@ def control_z(size, control, target):
         binary = list(format(i, f))
 
         row = zeros_list(2 ** size)
+        conditions = [binary[-i] == "1" for i in controls]
 
-        if binary[-control] == "1" and binary[-target] == "1":
+        if all(conditions) and binary[-target] == "1":
             row[i] = -1
         else:
             row[i] = 1
@@ -75,7 +80,7 @@ def control_z(size, control, target):
     return z
 
 
-def control_phase(size, control, target, phi):
+def control_phase(size, controls, target, phi):
     m = []
 
     for i in range(0, 2 ** size):
@@ -83,37 +88,15 @@ def control_phase(size, control, target, phi):
         binary = list(format(i, f))
 
         row = zeros_list(2 ** size)
+        conditions = [binary[-i] == "1" for i in controls]
 
-        if binary[-control] == "1" and binary[-target] == "1":
+        if all(conditions) and binary[-target] == "1":
             row[i] = cmath.exp(1j * phi)
         else:
             row[i] = 1
         m.append(row)
     p = Matrix(m)
     return p
-
-
-def toffoli(size, control1, control2, target):
-    m = []
-
-    for i in range(0, 2 ** size):
-        f = '0' + str(size) + 'b'
-        binary = list(format(i, f))
-
-        if binary[-control1] == "1" and binary[-control2] == "1":
-            if binary[-target] == "0":
-                binary[-target] = "1"
-            else:
-                binary[-target] = "0"
-
-        num = "".join(binary)
-        number = int(num, 2)
-
-        row = zeros_list(2 ** size)
-        row[number] = 1
-        m.append(row)
-    x = Matrix(m)
-    return x
 
 
 def zeros_list(n):

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -1,7 +1,9 @@
+import cmath
+
 from matrix import Matrix
 import constants as c
 from tensor_product import tensor_product
-import math
+
 
 '''
 Multi_Gates: constructs a large circuit matrix which acts as a gate that applies a specific gate to one or more qubits 
@@ -111,7 +113,7 @@ def control_phase(size, control, target, phi):
         row = zeros_list(2 ** size)
 
         if binary[-control] == "1" and binary[-target] == "1":
-            row[i] = math.e ** (1j * phi)
+            row[i] = cmath.exp(1j * phi)
         else:
             row[i] = 1
         m.append(row)
@@ -120,15 +122,34 @@ def control_phase(size, control, target, phi):
 
 
 def toffoli(size, control1, control2, target):
-    pass
+    m = []
+
+    for i in range(0, 2 ** size):
+        f = '0' + str(size) + 'b'
+        binary = list(format(i, f))
+
+        if binary[-control1] == "1" and binary[-control2] == "1":
+            if binary[-target] == "0":
+                binary[-target] = "1"
+            else:
+                binary[-target] = "0"
+
+        num = "".join(binary)
+        number = int(num, 2)
+
+        row = zeros_list(2 ** size)
+        row[number] = 1
+        m.append(row)
+    x = Matrix(m)
+    return x
 
 
 def zeros_list(n):
     x = []
     for i in range(n):
-        x.append(0)
+        x.append(0 + 0j)
     return x
 
 
 def phase_shift(phi):
-    return Matrix([[1, 0], [0, math.e ** (1j * phi)]])
+    return Matrix([[1, 0], [0, cmath.exp(1j * phi)]])

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -6,18 +6,22 @@ from tensor_product import tensor_product
 from typing import List
 
 
-# Notation note : |001> represents a 3 qubit system where the first qubit is |1> and the second and third qubit is
-# |0>
-# Targets and Controls work off this notation but you only need to enter the number of the qubit you want to
-# target/control
+# Notation note : |001> represents a 3 qubit system where the first qubit is
+# |1> and the second and third qubit is |0>
+# Targets and Controls work off this notation but you only need to enter the
+# number of the qubit you want to target/control
 def multi_gate(size: int, targets: list[int], gate: str, phi=complex(0)) -> Matrix:
     """
-    Constructs a (2**size by 2**size) gate matrix that applies a specific gate to one or more specified qubits
+    Constructs a (2**size by 2**size) gate matrix that applies a
+    specific gate to one or more specified qubits
 
     :param size: total number of qubits in circuit -> int
-    :param targets: list of qubits the specified gate will be applied to -> List[int]
-    :param gate: string character representing which specified gate we want to apply;
-                                h = hadamard, x = Pauli x, z = Pauli z, p = Phase gate
+    :param targets: list of qubits the specified gate will be
+                    applied to -> List[int]
+    :param gate: string character representing which specified gate we
+            want to apply;
+                h = hadamard, x = Pauli x, z = Pauli z, p = Phase gate
+
     :param phi: Phase angle for the phase gate -> complex number
     :return: Matrix([int])
     """
@@ -46,7 +50,8 @@ def multi_gate(size: int, targets: list[int], gate: str, phi=complex(0)) -> Matr
 
 def control_x(size, controls, target):
     """
-    Constructs a (2**size by 2**size) control-x gate with given controls and target
+    Constructs a (2**size by 2**size) control-x gate with
+    given controls and target
     :param size: total number of qubits in circuit ->
     :param controls: List of control qubits -> List[int]
     :param target: target qubit the x gate will be applied to -> int
@@ -78,10 +83,12 @@ def control_x(size, controls, target):
 
 def control_z(size, controls, target):
     """
-    Constructs a (2**size by 2**size) control-z gate with given controls and target
+    Constructs a (2**size by 2**size) control-z gate with
+     given controls and target
     :param size: total number of qubits in circuit ->
     :param controls: List of control qubits -> List[int]
-    :param target: target qubit the z gate will be applied to -> int
+    :param target: target qubit the z gate will be
+                    applied to -> int
     :return: Matrix(int)
     """
     m = []
@@ -104,11 +111,14 @@ def control_z(size, controls, target):
 
 def control_phase(size, controls, target, phi):
     """
-    Constructs a (2**size by 2**size) control-phase gate with given controls and target
+    Constructs a (2**size by 2**size) control-phase gate with
+     given controls and target
     :param size: total number of qubits in circuit ->
     :param controls: List of control qubits -> List[int]
-    :param target: target qubit the phase gate will be applied to -> int
-    :param phi: angle the target qubit will be phase shifted by -> complex
+    :param target: target qubit the phase gate will be
+                    applied to -> int
+    :param phi: angle the target qubit will be phase
+                    shifted by -> complex
     :return: Matrix(complex)
     """
 

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -3,12 +3,14 @@ import cmath
 from matrix import Matrix
 import constants as c
 from tensor_product import tensor_product
+from typing import List
 
 
-# Notation note : |001> represents a 3 qubit system where the first qubit is |1> and the second and third qubit is |0>
-# Targets and Controls work off this notation
-
-def multi_gate(size: int, targets: list[int], gate: str, phi=complex(0)):
+# Notation note : |001> represents a 3 qubit system where the first qubit is |1> and the second and third qubit is
+# |0>
+# Targets and Controls work off this notation but you only need to enter the number of the qubit you want to
+# target/control
+def multi_gate(size: int, targets: list[int], gate: str, phi=complex(0)) -> Matrix:
     """
     Constructs a (2**size by 2**size) gate matrix that applies a specific gate to one or more specified qubits
 
@@ -29,7 +31,7 @@ def multi_gate(size: int, targets: list[int], gate: str, phi=complex(0)):
     elif gate == "p":
         g = phase_shift(phi)
     else:
-        return
+        return c.IDENTITY
 
     m = Matrix([1])
     t = [x - 1 for x in targets]
@@ -56,7 +58,7 @@ def control_x(size, controls, target):
         f = '0' + str(size) + 'b'
         binary = list(format(i, f))
 
-        conditions = [binary[-i] == "1" for i in controls]
+        conditions = [binary[-j] == "1" for j in controls]
 
         if all(conditions):
             if binary[-target] == "0":
@@ -65,7 +67,7 @@ def control_x(size, controls, target):
                 binary[-target] = "0"
 
         num = "".join(binary)
-        number = int(num, 2)
+        number = int(num, base=2)
 
         row = zeros_list(2 ** size)
         row[number] = 1
@@ -89,7 +91,7 @@ def control_z(size, controls, target):
         binary = list(format(i, f))
 
         row = zeros_list(2 ** size)
-        conditions = [binary[-i] == "1" for i in controls]
+        conditions = [binary[-j] == "1" for j in controls]
 
         if all(conditions) and binary[-target] == "1":
             row[i] = -1
@@ -117,7 +119,7 @@ def control_phase(size, controls, target, phi):
         binary = list(format(i, f))
 
         row = zeros_list(2 ** size)
-        conditions = [binary[-i] == "1" for i in controls]
+        conditions = [binary[-j] == "1" for j in controls]
 
         if all(conditions) and binary[-target] == "1":
             row[i] = cmath.exp(1j * phi)
@@ -134,10 +136,7 @@ def zeros_list(n):
     :param n: size of list
     :return: list[int]
     """
-    x = []
-    for i in range(n):
-        x.append(0 + 0j)
-    return x
+    return [(0 + 0j) for _ in range(n)]
 
 
 def phase_shift(phi):

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -1,12 +1,13 @@
 from matrix import Matrix
 import constants as c
 from tensor_product import tensor_product
+import math
 
 '''
 Multi_Gates: constructs a large circuit matrix which acts as a gate that applies a specific gate to one or more qubits 
 Params:
     size - total number of qubits we're working with
-    targets - the specific qubits the gate is applied to (starting from the 0th qubit)
+    targets - the specific qubits the gate is applied to (starting from the 1st qubit)
 '''
 
 
@@ -47,9 +48,16 @@ def multi_z(size: int, targets: list[int]):
     return z
 
 
-def multi_phase_shift(size, phi):
+def multi_phase_shift(size, targets, phi):
+    p = Matrix([1])
+    t = [x - 1 for x in targets]
 
-    return
+    for i in range(size):
+        if i in t:
+            p = tensor_product(phase_shift(phi), p)
+        else:
+            p = tensor_product(c.IDENTITY, p)
+    return p
 
 
 def control_x(size, control, target):
@@ -93,9 +101,26 @@ def control_z(size, control, target):
     return z
 
 
+def control_phase(size, control, target, phi):
+    m = []
+
+    for i in range(0, 2 ** size):
+        f = '0' + str(size) + 'b'
+        binary = list(format(i, f))
+
+        row = zeros_list(2 ** size)
+
+        if binary[-control] == "1" and binary[-target] == "1":
+            row[i] = math.e ** (1j * phi)
+        else:
+            row[i] = 1
+        m.append(row)
+    p = Matrix(m)
+    return p
+
+
 def toffoli(size, control1, control2, target):
     pass
-
 
 
 def zeros_list(n):
@@ -105,6 +130,5 @@ def zeros_list(n):
     return x
 
 
-def phase_shift(size, phi):
-
-    return
+def phase_shift(phi):
+    return Matrix([[1, 0], [0, math.e ** (1j * phi)]])

--- a/qcp/matrix.py
+++ b/qcp/matrix.py
@@ -20,4 +20,3 @@ class Matrix:
 
     def __sub__(self, other):
         pass
-    

--- a/qcp/matrix.py
+++ b/qcp/matrix.py
@@ -1,0 +1,6 @@
+
+class matrix:
+
+    def __init__(self, state):
+        self.state = state
+    

--- a/qcp/matrix.py
+++ b/qcp/matrix.py
@@ -1,4 +1,4 @@
-class matrix:
+class Matrix:
 
     def __init__(self, state):
         pass

--- a/qcp/matrix.py
+++ b/qcp/matrix.py
@@ -1,6 +1,23 @@
-
 class matrix:
 
     def __init__(self, state):
-        self.state = state
+        pass
+
+    def __len__(self):
+        pass
+
+    def get_state(self):
+        pass
+
+    def set_state(self):
+        pass
+
+    def __add__(self, other):
+        pass
+
+    def __mul__(self, other):
+        pass
+
+    def __sub__(self, other):
+        pass
     

--- a/qcp/tensor_product.py
+++ b/qcp/tensor_product.py
@@ -1,0 +1,3 @@
+
+def tensor_product(a, b):
+    pass


### PR DESCRIPTION
### Hadamard
The 2x2 Hadamard Gate acts upon a single qubit to create a superposition and is represented by the matrix:
(1/ sqrt(2)) * [[1, 1], [1, -1]]

### X - Gate
The 2x2 Pauli x gate acts upon a qubit and applies a classical not to that qubit and is represented by the matrix:
[[0, 1], [1,0]]

The control-x gate works in a very similar way but requires a "control" qubit which determines whether a not is applied to a different "target" qubit. The 4x4 CX gate which acts on two qubits can be represented by the matrix:
[[1,0,0,0],
[0,1,0,0],
[0,0,0,1],
[0,0,1,0]]

### Z - Gate and Phase Shift Gate
The 2x2 Pauli z gate is represented by the matrix:
[[1, 0], [0, -1]]

and the Phase Shift gate is represented by the matrix:
[[1, 0], [0, exp(φi)]]

where the phase shift gate is equal to the z- gate if φ == π 

Both of these gates have a control-gate form which requires a control qubit to determine whether the phase shift/phase flip is applied to the target bit.

------------------
Using the tensor product and the identity matrix, we can construct matrices for all of these gates such that they apply to multiple qubits for any size circuit. The multi_gate function in gates.py does exactly this.
