### PR TITLE
Enable Dependabot on this repo:

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+    # Maintain changes for python packages:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - Tiernan8r
+    # Maintain updates on the github actions:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - Tiernan8r

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-click==8.0.3
+click==8.0.4
     # via pip-tools
 distlib==0.3.4
     # via virtualenv
-filelock==3.4.2
+filelock==3.6.0
     # via
     #   tox
     #   virtualenv
@@ -20,7 +20,7 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.5.1
     # via -r requirements.in
-platformdirs==2.5.0
+platformdirs==2.5.1
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -38,7 +38,7 @@ tomli==2.0.1
     # via pep517
 tox==3.24.5
     # via -r requirements.in
-virtualenv==20.13.1
+virtualenv==20.13.2
     # via tox
 wheel==0.37.1
     # via pip-tools

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -16,6 +16,3 @@ mypy
 pytest
 pytest-cov
 pytest-flake8
-pytest-mock
-pytest-optional-tests
-pylint

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,24 +4,16 @@
 #
 #    pip-compile --output-file=test-requirements.txt test-requirements.in
 #
-astroid==2.9.3
-    # via pylint
 attrs==21.4.0
     # via pytest
-coverage[toml]==6.3.1
+coverage[toml]==6.3.2
     # via pytest-cov
 flake8==4.0.1
     # via pytest-flake8
 iniconfig==1.1.1
     # via pytest
-isort==5.10.1
-    # via pylint
-lazy-object-proxy==1.7.1
-    # via astroid
 mccabe==0.6.1
-    # via
-    #   flake8
-    #   pylint
+    # via flake8
 mypy==0.931
     # via -r test-requirements.in
 mypy-extensions==0.4.3
@@ -30,10 +22,6 @@ packaging==21.3
     # via
     #   -c requirements.txt
     #   pytest
-platformdirs==2.5.0
-    # via
-    #   -c requirements.txt
-    #   pylint
 pluggy==1.0.0
     # via
     #   -c requirements.txt
@@ -46,8 +34,6 @@ pycodestyle==2.8.0
     # via flake8
 pyflakes==2.4.0
     # via flake8
-pylint==2.12.2
-    # via -r test-requirements.in
 pyparsing==3.0.7
     # via
     #   -c requirements.txt
@@ -57,33 +43,15 @@ pytest==7.0.1
     #   -r test-requirements.in
     #   pytest-cov
     #   pytest-flake8
-    #   pytest-mock
-    #   pytest-optional-tests
 pytest-cov==3.0.0
     # via -r test-requirements.in
 pytest-flake8==1.0.7
     # via -r test-requirements.in
-pytest-mock==3.7.0
-    # via -r test-requirements.in
-pytest-optional-tests==0.1.1
-    # via -r test-requirements.in
-toml==0.10.2
-    # via
-    #   -c requirements.txt
-    #   pylint
 tomli==2.0.1
     # via
     #   -c requirements.txt
     #   coverage
     #   mypy
     #   pytest
-typing-extensions==4.0.1
-    # via
-    #   astroid
-    #   mypy
-    #   pylint
-wrapt==1.13.3
-    # via astroid
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+typing-extensions==4.1.1
+    # via mypy


### PR DESCRIPTION
Dependabot is a tool provided by Github that tracks the dependencies of
your codebase, and proposes updates to the dependencies whenever a new
version becomes available.

Enable this functionality for the `pip` packages and github workflows in
this repo.

Also update the `test-requirements.in` manifest to remove some unused
dependencies. `tox -e update-pins` was re-run to recompile
`requirements.txt` and `test-requirements.txt`.
