### PR TITLE
Patch error in `SparseMatrix` dot product calculation:

### DIFF
--- a/qcp/matrices/sparse_matrix.py
+++ b/qcp/matrices/sparse_matrix.py
@@ -270,17 +270,19 @@ class SparseMatrix(Matrix):
             return self._dot(other)
 
     def _dot(self, other: Matrix) -> Matrix:
-        assert len(other) > 0, "taking dot product with empty matrix"
-        assert len(self) == len(other.columns()[
-            0]), "matrices don't match on their row/column dimensions"
+        assert other.num_rows > 0, "taking dot product with empty matrix"
+        assert self.num_columns == other.num_rows, "matrices don't match on their row/column dimensions"
 
-        new_matrix = SparseMatrix([], w=len(other[0]), h=self._col)
+        new_matrix = SparseMatrix([], w=other.num_columns, h=self.num_rows)
 
         entries: SPARSE = {
-            i: {} for i in range(self._col)
+            i: {} for i in range(self.num_columns)
         }
+
+        print(entries)
+
         for i, row in self._entries.items():
-            for j in range(new_matrix._col):
+            for j in range(new_matrix.num_columns):
                 # only need to calculate using the non-zero entries of self
                 # TODO: Can further optimise this 'other' is also a
                 # SparseMatrix by only using it's non-zero entries too

--- a/tests/matrices/test_sparse_matrix.py
+++ b/tests/matrices/test_sparse_matrix.py
@@ -290,6 +290,18 @@ def test_sp_m_mul_dot_product():
     assert (TEST_4x4 * TEST_4x4).get_state() == C4x4.get_state()
 
 
+def test_sp_m_column_mul():
+
+    A = SparseMatrix([[1, 1], [1, -1]])
+    B = SparseMatrix([[1], [0]])
+
+    C = A * B
+
+    expected = SparseMatrix([[1], [1]])
+
+    assert C.get_state() == expected.get_state()
+
+
 def test_sp_m_str():
     expected1x1 = "[  1]"
     assert str(TEST_1x1) == expected1x1


### PR DESCRIPTION
Fix an error that myself and Finn came across in how the `SparseMatrix`
calculates the dot product. The resultant matrix's row/column dimensions
were incorrect after the calculation when taking the dot product of
non-square matrices.

This should hopefully be patched now, and a new test exists that should
catch the error arising again.
