### PR TITLE
Fix edge case in Matrix dot producting:

### DIFF
--- a/qcp/matrices/sparse_matrix.py
+++ b/qcp/matrices/sparse_matrix.py
@@ -218,7 +218,9 @@ class SparseMatrix(Matrix):
         return list_representation
 
     def transpose(self) -> Matrix:
-        entries = {}
+        entries: SPARSE = {
+            k: {} for k in range(self._col)
+        }
         for i, row in self._entries.items():
             for j, v in row.items():
                 if j not in entries:
@@ -281,7 +283,7 @@ class SparseMatrix(Matrix):
         new_matrix = SparseMatrix([], w=other.num_columns, h=self.num_rows)
 
         entries: SPARSE = {
-            i: {} for i in range(self.num_columns)
+            i: {} for i in range(self.num_rows)
         }
 
         for i, row in self._entries.items():

--- a/tests/matrices/test_sparse_matrix.py
+++ b/tests/matrices/test_sparse_matrix.py
@@ -153,6 +153,23 @@ def test_sp_m_transpose():
 
     assert A.transpose().get_state() == B.get_state()
 
+    # Verify an edge case in column vector multiplication is solved
+    v = SparseMatrix([[1], [2], [3], [4]])
+    # column x row vectors produce a matrix
+    C = v * v.transpose()
+    expected1 = SparseMatrix([[1, 2, 3, 4],
+                              [2, 4, 6, 8],
+                              [3, 6, 9, 12],
+                              [4, 8, 12, 16]])
+
+    assert C.get_state() == expected1.get_state()
+
+    # row x column vector produces a scalar (1x1 matrix in this case...)
+    D = v.transpose() * v
+    expected2 = SparseMatrix([[30]])
+
+    assert D.get_state() == expected2.get_state()
+
 
 def test_sp_m_conjugate():
     # Non-complex values shoule be unchanged.


### PR DESCRIPTION
Fix index error when calculating the dot product between row and column vectors
due to missing indices in the dictionaries of the underlying `SparseMatrix`
objects.

This error was occuring in two places, firstly when the `transpose()` was being
calculated, the dictionary rows were only populated if they had non-zero
entries, while the general `SparseMatrix` code always assumed the zero rows were
represented as empty dicts.

Secondly, since most of the tests are implemented using square matrices, there
was an error in which dimension to use in the new matrix when calculating the
dot product, previously the number of rows of the new matrix was set using the
number of rows of the current matrix, when it should have been using the number
of columns. This has been resolved.

A new test has been added to verify the code works as expected.
