### PR TITLE
Add method to "measure" a quantum register state:

### DIFF
--- a/qcp/grovers_algorithm.py
+++ b/qcp/grovers_algorithm.py
@@ -1,4 +1,5 @@
 from qcp.matrices import DefaultMatrix
+import qcp.register as reg
 import random
 import qcp.gates as g
 
@@ -115,7 +116,7 @@ class Grovers:
         :return: the state observed and the probability of measuring
                 said state
         """
-        p = list(map(lambda x: x ** 2, self.state.transpose().get_state()[0]))
+        p = reg.measure(self.state)
         # list of weighted probabilities with the index representing the state
 
         observed = random.choices([i for i in range(len(p))], p, k=1)

--- a/qcp/matrices/dense_matrix.py
+++ b/qcp/matrices/dense_matrix.py
@@ -46,6 +46,12 @@ class DenseMatrix(Matrix):
             ] for j in range(n)
         ])
 
+    @staticmethod
+    def zeros(nrow, ncol=1) -> Matrix:
+        # Create zero matrix with dimension (nrow,ncol)
+        # Class method used to handle the creation of new object
+        return DenseMatrix([[0 for _ in range(ncol)] for _ in range(nrow)])
+
     def __len__(self) -> int:
         return self.num_columns
 
@@ -80,12 +86,6 @@ class DenseMatrix(Matrix):
             [self._state[i][j] for i in range(len(self))]
             for j in range(len(self[0]))
         ]
-
-    @classmethod
-    def zeros(cls, nrow, ncol=1):
-        # Create zero matrix with dimension (nrow,ncol)
-        # Class method used to handle the creation of new object
-        return cls([[0 for _ in range(ncol)] for _ in range(nrow)])
 
     def __iter__(self):
         return iter(self.get_state())
@@ -140,7 +140,7 @@ class DenseMatrix(Matrix):
         for i in range(N):
             total_string += "[" + \
                 ",".join([f"{c:3.3g}" for c in self._state[i]]) + "]" + \
-                (lambda i, N: "\n" if i < N - 1 else "")(i, N)
+                self._optional_newline(i, N)
         return total_string
 
     def conjugate(self) -> Matrix:

--- a/qcp/matrices/matrix.py
+++ b/qcp/matrices/matrix.py
@@ -82,3 +82,6 @@ class Matrix(ABC):
 
     def __str__(self) -> str:
         pass
+
+    def _optional_newline(self, i: int, N: int) -> str:
+        return "\n" if i < N - 1 else ""

--- a/qcp/matrices/sparse_matrix.py
+++ b/qcp/matrices/sparse_matrix.py
@@ -155,7 +155,7 @@ class SparseMatrix(Matrix):
         return self._row
 
     def _get_row(self, i: int) -> SparseVector:  # type: ignore[override]
-        assert i < len(self), "index out of range"
+        assert i < self.num_rows, "index out of range"
 
         entry = {}
         if i in self._entries:
@@ -164,16 +164,15 @@ class SparseMatrix(Matrix):
         return SparseVector(entry, self.num_columns)
 
     def __getitem__(self, i: int) -> SparseVector:  # type: ignore[override]
-        assert i < len(self), "index out of range"
         return self._get_row(i)
 
     def __setitem__(self, i: int, v:  # type: ignore[override]
                     Union[SparseVector, List[SCALARS], Dict[int, SCALARS]]
                     ):
-        assert i < len(self), "index out of range"
+        assert i < self.num_rows, "index out of range"
         sv = None
         if isinstance(v, list):
-            assert len(v) == len(self[i]), "row dimension does not match"
+            assert len(v) == self.num_columns, "row dimension does not match"
             sv = SparseVector(v, self.num_rows)
         elif isinstance(v, dict):
             assert max(v.keys()) + 1 < self.num_rows, "row too wide"
@@ -349,6 +348,5 @@ class SparseMatrix(Matrix):
             total_string += "[" + \
                 ",".join(row_repr) + "]"
             # Don't add newline for last row:
-            total_string += (lambda i, N: "\n" if i <
-                             N - 1 else "")(i, self.num_rows)
+            total_string += self._optional_newline(i, self.num_rows)
         return total_string

--- a/qcp/register.py
+++ b/qcp/register.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# Copyright 2022 Tiernan8r
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from qcp.matrices import Matrix
+import cmath
+from qcp.matrices.types import VECTOR
+
+
+def measure(mat: Matrix) -> VECTOR:
+    """Convert the qbit states into probability amplitudes"""
+    assert mat.num_columns == 1, \
+        "can only measure the probabilities of column matrices"
+    states = mat.get_state()
+
+    probabilities = [s[0]**2 for s in states]
+
+    # Normalise the probabilities if they aren't, but avoid divide by
+    # 0 errors
+    magnitude = sum(probabilities)
+    if not cmath.isclose(magnitude, 1) and not cmath.isclose(magnitude, 0):
+        probabilities = [p / magnitude for p in probabilities]
+
+    return probabilities

--- a/qcp/ui/widgets/graph_widget.py
+++ b/qcp/ui/widgets/graph_widget.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from PySide6 import QtWidgets
 from qcp.matrices import Matrix
+import qcp.register as reg
 from qcp.ui.widgets.embedded_graph import EmbeddedGraph
 from typing import List, Any
 
@@ -32,12 +33,12 @@ class GraphWidget(EmbeddedGraph):
         # TODO: remove placeholders
         x: List[Any] = list(range(10))
         y = [2**i for i in x]
-        x = [f"|{bin(i)[2:]}>" for i in x]
 
         if qregister is not None:
-            x = list(range(qregister.num_columns))
-            # TODO: someway to measure qregister
-            y = qregister.measure()  # type: ignore
+            x = list(range(qregister.num_rows))
+            y = reg.measure(qregister)
+
+        x = [f"|{bin(i)[2:]}>" for i in x]
 
         self._plot_line(x, y, title=title,
                         xlabel=xlabel, ylabel=ylabel)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,44 @@
+# Copyright 2022 Tiernan8r
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from qcp.matrices import DefaultMatrix
+import qcp.register as reg
+import math
+
+
+def test_measure():
+    # Test non-column matrix
+    A = DefaultMatrix([[1, 2], [3, 4]])
+
+    with pytest.raises(AssertionError) as ae:
+        _ = reg.measure(A)
+    assert ae.match("can only measure the probabilities of column matrices")
+
+    # Make sure divide by 0 error not raised
+    Z = DefaultMatrix([[0], [0], [0], [0]])
+    try:
+        _ = reg.measure(Z)
+    except ZeroDivisionError as zde:
+        assert False, "expected no ZeroDivisionError"
+
+    # Test probabilities come out as expected
+    factor = 1 / math.sqrt(2)
+    B = factor * DefaultMatrix([[1], [1]])
+    prob = reg.measure(B)
+    assert math.isclose(prob[0], 0.5)
+
+    # Test normalisation works 
+    C = DefaultMatrix([[1],[1]])
+    prob2 = reg.measure(C)
+    assert math.isclose(prob2[0], 0.5)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -29,7 +29,7 @@ def test_measure():
     Z = DefaultMatrix([[0], [0], [0], [0]])
     try:
         _ = reg.measure(Z)
-    except ZeroDivisionError as zde:
+    except ZeroDivisionError:
         assert False, "expected no ZeroDivisionError"
 
     # Test probabilities come out as expected
@@ -38,7 +38,7 @@ def test_measure():
     prob = reg.measure(B)
     assert math.isclose(prob[0], 0.5)
 
-    # Test normalisation works 
-    C = DefaultMatrix([[1],[1]])
+    # Test normalisation works
+    C = DefaultMatrix([[1], [1]])
     prob2 = reg.measure(C)
     assert math.isclose(prob2[0], 0.5)


### PR DESCRIPTION
Add a simple `measure()` method in a newfile `register.py` that converts a given
column matrix (representing our quantum register), and calculates the
probabilities for the qbits to be in each state.

Use this new method within the Grover's Algorithm, and in the UI (though this is
still not fully implemented...)
