### PR TITLE
Fix thread crash in UI:

### DIFF
--- a/qcp/ui/components/button_component.py
+++ b/qcp/ui/components/button_component.py
@@ -55,7 +55,7 @@ class ButtonComponent(AbstractComponent):
 
         self.pb_thread = ProgressBarThread(self.progress_bar.minimum(),
                                            self.progress_bar.maximum())
-        self.pb_thread.progressBarValueChange.connect(self._draw_progress)
+        self.pb_thread.progress_bar_value_change.connect(self._draw_progress)
         self.pb_thread.finished.connect(self._hide_progress_bar)
         # self.pb_thread.started.connect(self._show_progress_bar)
 
@@ -144,7 +144,7 @@ class ProgressBarThread(QtCore.QThread):
     every tick, so that it fills slowly, then resets to zero when
     full.
     """
-    progressBarValueChange = QtCore.Signal(int)
+    progress_bar_value_change = QtCore.Signal(int)
 
     def __init__(self, min: int, max: int, parent=None):
         """
@@ -170,7 +170,7 @@ class ProgressBarThread(QtCore.QThread):
             if val < self.min:
                 val = self.min
 
-            self.progressBarValueChange.emit(val)
+            self.progress_bar_value_change.emit(val)
             self.pb_val = val
             self.msleep(BUTTON_PROGRESS_BAR_TICK_RATE)
 

--- a/qcp/ui/components/button_component.py
+++ b/qcp/ui/components/button_component.py
@@ -132,16 +132,15 @@ class ProgressBarThread(QtCore.QThread):
     full.
     """
 
-    def __init__(self, progress_bar: QtWidgets.QProgressBar, parent=None):
+    def __init__(self, progress_bar: QtWidgets.QProgressBar):
         """
         Setup the ProgressBarThread QThread, referencing the progress bar
         widget to increment.
 
         :param QtWidgets.QProgressBar progress_bar: The progress bar to
             animate
-        :param QtCore.QObject parent: A parent element for the QThread.
         """
-        QtCore.QThread.__init__(self, parent)
+        QtCore.QThread.__init__(self)
         self.pb = progress_bar
         self.exiting = False
 

--- a/qcp/ui/components/button_component.py
+++ b/qcp/ui/components/button_component.py
@@ -57,7 +57,6 @@ class ButtonComponent(AbstractComponent):
                                            self.progress_bar.maximum())
         self.pb_thread.progress_bar_value_change.connect(self._draw_progress)
         self.pb_thread.finished.connect(self._hide_progress_bar)
-        # self.pb_thread.started.connect(self._show_progress_bar)
 
         self.search_button.clicked.connect(self.initiate_search)
         self.cancel_button.clicked.connect(self.cancel_search)

--- a/qcp/ui/components/button_component.py
+++ b/qcp/ui/components/button_component.py
@@ -132,7 +132,7 @@ class ProgressBarThread(QtCore.QThread):
     full.
     """
 
-    def __init__(self, progress_bar: QtWidgets.QProgressBar):
+    def __init__(self, progress_bar: QtWidgets.QProgressBar, parent=None):
         """
         Setup the ProgressBarThread QThread, referencing the progress bar
         widget to increment.
@@ -140,7 +140,7 @@ class ProgressBarThread(QtCore.QThread):
         :param QtWidgets.QProgressBar progress_bar: The progress bar to
             animate
         """
-        QtCore.QThread.__init__(self)
+        super().__init__(parent)
         self.pb = progress_bar
         self.exiting = False
 

--- a/qcp/ui/components/button_component.py
+++ b/qcp/ui/components/button_component.py
@@ -129,11 +129,21 @@ class ButtonComponent(AbstractComponent):
 
     @QtCore.Slot(int)
     def _draw_progress(self, val: int):
+        """
+        Set the progress bar widget to the provided value whenever the
+        signal is called.
+
+        :param int val: The value to set the progress bar to, no checks
+        are performed on it's value.
+        """
         if self.progress_bar.isHidden():
             self.progress_bar.show()
         self.progress_bar.setValue(val)
 
     def _hide_progress_bar(self):
+        """
+        Hide the progress bar widget.
+        """
         self.progress_bar.hide()
 
 
@@ -147,11 +157,11 @@ class ProgressBarThread(QtCore.QThread):
 
     def __init__(self, min: int, max: int, parent=None):
         """
-        Setup the ProgressBarThread QThread, referencing the progress bar
-        widget to increment.
+        Setup the ProgressBarThread QThread, to calculate the progress
+        bar ticker value every iteration.
 
-        :param QtWidgets.QProgressBar progress_bar: The progress bar to
-            animate
+        :param int min: The minimum value allowed for the progress bar
+        :param int max: The maximum allowed value for the progress bar
         """
         super().__init__(parent)
         self.exiting = False

--- a/qcp/ui/components/simulator_component.py
+++ b/qcp/ui/components/simulator_component.py
@@ -57,6 +57,8 @@ class SimulatorComponent(AbstractComponent):
         """
         self._find_widgets()
         self.qcp_thread = SimulateQuantumComputerThread()
+        self.qcp_thread.simulation_result_signal.connect(
+            self._simulation_results)
 
         self.qcp_thread.finished.connect(self.update_lcd_displays)
         # Hide the cancel button if the calculation finishes
@@ -82,8 +84,12 @@ class SimulatorComponent(AbstractComponent):
         if not self.qcp_thread.isRunning():
             self.qcp_thread.exiting = False
             self.qcp_thread.start()
-            while not self.qcp_thread.isRunning():
-                time.sleep(THREAD_PAUSE)
+            # while not self.qcp_thread.isRunning():
+            #     time.sleep(THREAD_PAUSE)
+
+    @QtCore.Slot(float)
+    def _simulation_results(self, float):
+        pass
 
     def simulation_finished(self):
         """
@@ -111,6 +117,7 @@ class SimulateQuantumComputerThread(QtCore.QThread):
     QThread object to handle the running of the Quantum Computer
     Simulation, input/output is passed back to the main thread by pipes.
     """
+    simulation_result_signal = QtCore.Signal(float)
 
     def __init__(self, parent=None):
         """

--- a/qcp/ui/components/simulator_component.py
+++ b/qcp/ui/components/simulator_component.py
@@ -86,6 +86,10 @@ class SimulatorComponent(AbstractComponent):
 
     @QtCore.Slot(float)
     def _simulation_results(self, float):
+        """
+        Signal catcher to read in the simulation results from the
+        QThread that it is calculated in.
+        """
         pass
 
     def simulation_finished(self):

--- a/qcp/ui/components/simulator_component.py
+++ b/qcp/ui/components/simulator_component.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 from PySide6 import QtWidgets
 from PySide6 import QtCore
-import time
 from qcp.ui.components import AbstractComponent, \
     ButtonComponent, GraphComponent
-from qcp.ui.constants import THREAD_PAUSE, LCD_CLASSICAL, LCD_GROVER
+from qcp.ui.constants import LCD_CLASSICAL, LCD_GROVER
 
 
 class SimulatorComponent(AbstractComponent):

--- a/qcp/ui/components/simulator_component.py
+++ b/qcp/ui/components/simulator_component.py
@@ -112,13 +112,11 @@ class SimulateQuantumComputerThread(QtCore.QThread):
     Simulation, input/output is passed back to the main thread by pipes.
     """
 
-    def __init__(self, parent=None):
+    def __init__(self):
         """
         Setup the SimulateQuantumComputerThread QThread.
-
-        :param QtCore.QObject parent: A parent element for the QThread.
         """
-        QtCore.QThread.__init__(self, parent)
+        QtCore.QThread.__init__(self)
         self.exiting = False
 
     def run(self):

--- a/qcp/ui/components/simulator_component.py
+++ b/qcp/ui/components/simulator_component.py
@@ -112,11 +112,11 @@ class SimulateQuantumComputerThread(QtCore.QThread):
     Simulation, input/output is passed back to the main thread by pipes.
     """
 
-    def __init__(self):
+    def __init__(self, parent=None):
         """
         Setup the SimulateQuantumComputerThread QThread.
         """
-        QtCore.QThread.__init__(self)
+        super().__init__(parent)
         self.exiting = False
 
     def run(self):

--- a/qcp/ui/components/simulator_component.py
+++ b/qcp/ui/components/simulator_component.py
@@ -83,8 +83,6 @@ class SimulatorComponent(AbstractComponent):
         if not self.qcp_thread.isRunning():
             self.qcp_thread.exiting = False
             self.qcp_thread.start()
-            # while not self.qcp_thread.isRunning():
-            #     time.sleep(THREAD_PAUSE)
 
     @QtCore.Slot(float)
     def _simulation_results(self, float):


### PR DESCRIPTION
Fix how the threads implemented in the UI pass values around to avoid an
edgecase crash when updating the progress bar.

UI drawing events have to be called from the main thread, so calculate the
progress bar values in a QThread, and then using a signal event, call a method
that draws those values within the main thread, this allows us to have our cake
and eat it too.

Put in a placeholder implementation of this for the SimulationComputationThread
too, though it is currently not being used.
