### PR TITLE
Patch the CNOT gate:

### DIFF
--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -125,10 +125,6 @@ def control_x(size: int, controls: List[int], target: int) -> Matrix:
     # bitmask is 10101 in binary notation
     mask = sum(2**c for c in set(controls))
 
-    # Invert all bits in place in the bitmask
-    invertor = sum(2**i for i in range(size))
-    flip_mask = mask ^ invertor
-
     # Find the bit index of the target
     target_bit = 2**target
 
@@ -136,10 +132,10 @@ def control_x(size: int, controls: List[int], target: int) -> Matrix:
     for i in range(0, n):
         # If the bits are targeted and meet the mask condition, it needs
         # to be flipped
-        condition = (i ^ flip_mask) & mask
+        condition = i & mask
 
         x = i
-        if condition:
+        if condition >= mask:
             # bit flip the targetted bit by the control bits
             x ^= target_bit
 

--- a/qcp/gates.py
+++ b/qcp/gates.py
@@ -136,12 +136,12 @@ def control_x(size: int, controls: List[int], target: int) -> Matrix:
     for i in range(0, n):
         # If the bits are targeted and meet the mask condition, it needs
         # to be flipped
-        condition = (i & target_bit) & flip_mask
+        condition = (i ^ flip_mask) & mask
 
         x = i
         if condition:
             # bit flip the targetted bit by the control bits
-            x ^= mask
+            x ^= target_bit
 
         m[i] = {x: 1}
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -94,7 +94,7 @@ def test_control_x():
 
     # Two qbit state has two options for the control/target position:
     # Test for 1st expected result
-    cx_4x4 = gts.control_x(2, [0], 1)
+    cx_4x4 = gts.control_x(2, [1], 0)
     expected_4x4 = SparseMatrix([
         [1, 0, 0, 0],
         [0, 1, 0, 0],
@@ -104,7 +104,7 @@ def test_control_x():
     assert cx_4x4.get_state() == expected_4x4.get_state()
 
     # Test for second:
-    cx_4x4_2 = gts.control_x(2, [1], 0)
+    cx_4x4_2 = gts.control_x(2, [0], 1)
     expected_4x4_2 = SparseMatrix([
         [1, 0, 0, 0],
         [0, 0, 0, 1],
@@ -147,9 +147,9 @@ def test_control_x():
     transform_3qbits = cx_8x8 * three_qbits
     expected_3qbits = SparseMatrix([
         [0],  # |000>
-        [0],  # |001>
+        [1],  # |001>
         [0],  # |010>
-        [1],  # |011>
+        [0],  # |011>
         [0],  # |100>
         [0],  # |101>
         [0],  # |110>

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -135,25 +135,25 @@ def test_control_x():
     cx_8x8 = gts.control_x(3, [1], 0)
     # Set the 3 qbit state to initially be in |001> state
     three_qbits = SparseMatrix([
-        [0],  # |000>
-        [1],  # |001>
-        [0],  # |010>
-        [0],  # |011>
-        [0],  # |100>
-        [0],  # |101>
-        [0],  # |110>
-        [0]  # |111>
+        [1],  # |000>
+        [2],  # |001>
+        [3],  # |010>
+        [4],  # |011>
+        [5],  # |100>
+        [6],  # |101>
+        [7],  # |110>
+        [8]  # |111>
     ])
     transform_3qbits = cx_8x8 * three_qbits
     expected_3qbits = SparseMatrix([
-        [0],  # |000>
-        [1],  # |001>
-        [0],  # |010>
-        [0],  # |011>
-        [0],  # |100>
-        [0],  # |101>
-        [0],  # |110>
-        [0]  # |111>
+        [1],  # |000>
+        [2],  # |001>
+        [4],  # |010>
+        [3],  # |011>
+        [5],  # |100>
+        [6],  # |101>
+        [8],  # |110>
+        [7]  # |111>
     ])
 
     assert transform_3qbits.get_state() == expected_3qbits.get_state()

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -158,6 +158,22 @@ def test_control_x():
 
     assert transform_3qbits.get_state() == expected_3qbits.get_state()
 
+    # Test for multiple controls:
+    cx_8x8_2 = gts.control_x(3, [1, 2], 0)
+    transform_3qbits_2 = cx_8x8_2 * three_qbits
+    expected_3qbits_2 = SparseMatrix([
+        [1],  # |000>
+        [2],  # |001>
+        [3],  # |010>
+        [4],  # |011>
+        [5],  # |100>
+        [6],  # |101>
+        [8],  # |110>
+        [7]  # |111>
+    ])
+
+    assert transform_3qbits_2.get_state() == expected_3qbits_2.get_state()
+
 
 def test_control_z():
     # Gate needs a minimum of two qubits to make sense


### PR DESCRIPTION
Fix the bit logic for the CNOT gate.

The existing implementation was working for the simple case of a 4x4 system,
but did not generalise to nxn.

Fix the bit logic to work properly, and verify with a few more tests.