### PR TITLE
Quick fix for CLI input on non GUI enabled systems:

### DIFF
--- a/qcp/cli/parser.py
+++ b/qcp/cli/parser.py
@@ -21,7 +21,6 @@ from typing import Dict, List, Tuple
 
 import qcp.cli.interpret as i
 import qcp.cli.usage as u
-import qcp.gui.main as gui
 from qcp.cli.constants import (ALGORITHM_LONG, DEFAULT_ALGORITHM,
                                DEFAULT_TARGET, FLAG_MAPPING, GUI_LONG,
                                HELP_LONG, TARGET_LONG)
@@ -91,7 +90,15 @@ def read_cli(args: List[str]):
         u.usage()
 
     if GUI_LONG in flags:
-        gui.initialise_ui()
+        try:
+            # Need to put import here, as not all terminal connections support
+            # a UI (e.g: an ssh connection...)
+            import qcp.gui.main as gui
+            gui.initialise_ui()
+        except ImportError as ie:
+            print("Could not start up GUI:", file=sys.stderr)
+            print(ie)
+            exit(1)
 
     if ALGORITHM_LONG not in flags:
         flags[ALGORITHM_LONG] = DEFAULT_ALGORITHM

--- a/qcp/cli/usage.py
+++ b/qcp/cli/usage.py
@@ -33,7 +33,7 @@ FLAGS:
                         s   = Toy Sudoku solver
                     Defaults to '{DEFAULT_ALGORITHM}' if unset
     {HELP_SHORT}/{HELP_LONG}       Display this prompt
-    {GUI_SHORT}/{GUI_LONG}      Display the GUI.
+    {GUI_SHORT}/{GUI_LONG}      Display the GUI (if supported).
 
 The CLI options vary by choice of algorithm:
 


### PR DESCRIPTION
The github actions running the `tox-tests` check does not support a GUI,
so the tests for CLI input were failing on the new check to initialise
the GUI since it's not supported.

Tweak how the GUI is initialised to catch any errors like this and print
to the user.
