### PR TITLE
Tweak Docs:

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Tiernan8r'
 author = 'Tiernan8r, hyoong, JabethM, nys1998, s1960329, RiddhiYaddav'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.3'
+release = '1.1.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -2,6 +2,6 @@ qcp
 ===
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 10
 
    qcp

--- a/docs/source/qcp.algorithms.rst
+++ b/docs/source/qcp.algorithms.rst
@@ -28,6 +28,14 @@ qcp.algorithms.phase\_estimation module
    :undoc-members:
    :show-inheritance:
 
+qcp.algorithms.phase\_estimation\_unitary\_matrices module
+----------------------------------------------------------
+
+.. automodule:: qcp.algorithms.phase_estimation_unitary_matrices
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 qcp.algorithms.sudoku module
 ----------------------------
 

--- a/docs/source/qcp.gui.components.phase_estimation.rst
+++ b/docs/source/qcp.gui.components.phase_estimation.rst
@@ -12,6 +12,14 @@ qcp.gui.components.phase\_estimation.button\_component module
    :undoc-members:
    :show-inheritance:
 
+qcp.gui.components.phase\_estimation.combo\_box\_component module
+-----------------------------------------------------------------
+
+.. automodule:: qcp.gui.components.phase_estimation.combo_box_component
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 qcp.gui.components.phase\_estimation.constants module
 -----------------------------------------------------
 

--- a/docs/source/qcp.gui.components.rst
+++ b/docs/source/qcp.gui.components.rst
@@ -54,6 +54,14 @@ qcp.gui.components.progress\_bar\_component module
    :undoc-members:
    :show-inheritance:
 
+qcp.gui.components.simulator\_component module
+----------------------------------------------
+
+.. automodule:: qcp.gui.components.simulator_component
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 qcp.gui.components.threaded\_compute module
 -------------------------------------------
 


### PR DESCRIPTION
Recompile the sphinx docs from docstrings, and update the configurations
so that the modules deeply nested in `qcp/gui` get documented as
they were being cut-off before.
