### PR TITLE
Change tox test coverage to not report on GUI code:

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from qcp import main
-import pytest
 
-
-def test_main():
-    with pytest.raises(SystemExit) as se:
-        main.main()
-    assert se.match("0")
+# .coveragerc to control pytest-cov
+[run]
+branch = True
+omit =
+    # omit the qcp/gui dir
+    ./qcp/gui/*
+source =
+    ./qcp

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ usedevelop = False
 commands = flake8
 
 [testenv:tests]
-commands = pytest --cache-clear --verbose --cov=qcp \
+commands = pytest --cache-clear --verbose --cov-config=.coveragerc --cov=qcp \
               --cov-report=xml:coverage/python/coverage.xml \
               --cov-report=term \
               --junitxml=test-reports/pytest/results.xml {posargs} \


### PR DESCRIPTION
This generates a table of test coverage that is related to code
we have actually written tests for, rather than the GUI code which
is large and has no test code.

More of a quality of life PR, just results in the coverage table reported
by tox being more realistic in it's test coverage.
